### PR TITLE
More secure: using SDDL to represent security descriptors (SDDL_DEVOBJ_SYS_ALL_ADM_ALL)

### DIFF
--- a/WinRing0Sys/OpenLibSys.c
+++ b/WinRing0Sys/OpenLibSys.c
@@ -8,6 +8,7 @@
 //-----------------------------------------------------------------------------
 
 #include "OpenLibSys.h"
+#include <wdmsec.h>
 
 static ULONG refCount;
 
@@ -24,13 +25,15 @@ NTSTATUS DriverEntry(IN PDRIVER_OBJECT DriverObject, IN PUNICODE_STRING Registry
 
 	RtlInitUnicodeString(&ntDeviceName, NT_DEVICE_NAME);
 
-	NTSTATUS status = IoCreateDevice(
+	NTSTATUS status = IoCreateDeviceSecure(
 		DriverObject,					// Our Driver Object
 		0,								// We don't use a device extension
 		&ntDeviceName,					// Device name 
 		OLS_TYPE,						// Device type
 		FILE_DEVICE_SECURE_OPEN,		// Device characteristics
 		FALSE,							// Not an exclusive device
+		&SDDL_DEVOBJ_SYS_ALL_ADM_ALL,
+		NULL,
 		&deviceObject);				    // Returned ptr to Device Object
 
 	if (!NT_SUCCESS(status))

--- a/WinRing0Sys/WinRing0Sys.inf
+++ b/WinRing0Sys/WinRing0Sys.inf
@@ -19,7 +19,7 @@ WinRing0Sys_Device_CoInstaller_CopyFiles = 11
 1 = %DiskName%,,,""
 
 [SourceDisksFiles]
-WinRing0Sys.sys  = 1,,
+WinRing0x64.sys  = 1,,
 WdfCoInstaller$KMDFCOINSTALLERVERSION$.dll=1 ; make sure the number matches with SourceDisksNames
 
 ;*****************************************
@@ -36,7 +36,7 @@ WdfCoInstaller$KMDFCOINSTALLERVERSION$.dll=1 ; make sure the number matches with
 CopyFiles=Drivers_Dir
 
 [Drivers_Dir]
-WinRing0Sys.sys
+WinRing0x64.sys
 
 ;-------------- Service installation
 [WinRing0Sys_Device.NT.Services]

--- a/WinRing0Sys/WinRing0Sys.vcxproj
+++ b/WinRing0Sys/WinRing0Sys.vcxproj
@@ -63,6 +63,9 @@
     <ClCompile>
       <TreatWarningAsError>false</TreatWarningAsError>
     </ClCompile>
+    <Link>
+      <AdditionalDependencies>Wdmsec.lib;%(AdditionalDependencies)</AdditionalDependencies>
+    </Link>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <DriverSign>
@@ -71,6 +74,9 @@
     <ClCompile>
       <TreatWarningAsError>false</TreatWarningAsError>
     </ClCompile>
+    <Link>
+      <AdditionalDependencies>Wdmsec.lib;%(AdditionalDependencies)</AdditionalDependencies>
+    </Link>
   </ItemDefinitionGroup>
   <ItemGroup>
     <Inf Include="WinRing0Sys.inf" />


### PR DESCRIPTION
SDDL_DEVOBJ_SYS_ALL_ADM_ALL allows the kernel, system, and admin complete control over the device. No other users may access the device)